### PR TITLE
Add rand_bytes

### DIFF
--- a/src/crypto2.erl
+++ b/src/crypto2.erl
@@ -10,7 +10,8 @@
          hash_init/1,
          hash_update/2,
          hash_final/1,
-         rand_bytes/1
+         rand_bytes/1,
+         strong_rand_bytes/1
         ]).
 
 %%====================================================================
@@ -36,6 +37,9 @@ rand_bytes(NumBytes) ->
         error -> erlang:error(low_entropy);
         Data -> Data
     end.
+
+strong_rand_bytes(NumBytes) ->
+    rand_bytes(NumBytes).
 
 %%====================================================================
 %% Internal functions

--- a/src/crypto2.erl
+++ b/src/crypto2.erl
@@ -9,7 +9,8 @@
          hash/2,
          hash_init/1,
          hash_update/2,
-         hash_final/1
+         hash_final/1,
+         rand_bytes/1
         ]).
 
 %%====================================================================
@@ -30,6 +31,12 @@ hash_init(sha512) ->
 hash_update(_Context, _Data) -> "Undefined".
 hash_final(_Context) -> "Undefined".
 
+rand_bytes(NumBytes) ->
+    case rand_bytes_nif(NumBytes) of
+        error -> erlang:error(low_entropy);
+        Data -> Data
+    end.
+
 %%====================================================================
 %% Internal functions
 %%====================================================================
@@ -45,3 +52,4 @@ on_load() ->
 sha1_init() -> "Undefined".
 sha256_init() -> "Undefined".
 sha512_init() -> "Undefined".
+rand_bytes_nif(_NumBytes) -> "Undefined".

--- a/test/crypto2_SUITE.erl
+++ b/test/crypto2_SUITE.erl
@@ -192,4 +192,5 @@ long_sha512_digest() ->
 	       "de0ff244877ea60a" "4cb0432ce577c31b" "eb009c5c2c49aa2e" "4eadb217ad8cc09b").
 
 rand_bytes(_Config) ->
-    10 = byte_size(crypto2:rand_bytes(10)).
+    10 = byte_size(crypto2:rand_bytes(10)),
+    20 = byte_size(crypto2:strong_rand_bytes(20)).

--- a/test/crypto2_SUITE.erl
+++ b/test/crypto2_SUITE.erl
@@ -24,7 +24,8 @@
 
 all() -> [{group, sha},
           {group, sha256},
-          {group, sha512}
+          {group, sha512},
+          rand_bytes
          ].
 
 groups() -> [{sha, [], [hash]},
@@ -80,7 +81,9 @@ group_config(sha256 = Type, Config) ->
 group_config(sha512 = Type, Config) ->
     Msgs =  [rfc_4634_test1(), rfc_4634_test2(), long_msg()],
     Digests = rfc_4634_sha512_digests() ++ [long_sha512_digest()],
-    [{hash, {Type, Msgs, Digests}} | Config].
+    [{hash, {Type, Msgs, Digests}} | Config];
+group_config(_, Config) ->
+    Config.
 %%--------------------------------------------------------------------
 hexstr2bin(S) ->
     list_to_binary(hexstr2list(S)).
@@ -187,3 +190,6 @@ long_sha256_digest() ->
 long_sha512_digest() ->
     hexstr2bin("e718483d0ce76964" "4e2e42c7bc15b463" "8e1f98b13b204428" "5632a803afa973eb"
 	       "de0ff244877ea60a" "4cb0432ce577c31b" "eb009c5c2c49aa2e" "4eadb217ad8cc09b").
+
+rand_bytes(_Config) ->
+    10 = byte_size(crypto2:rand_bytes(10)).


### PR DESCRIPTION
The implementation for `erlang:rand_bytes` does not work for us because it does not check the return value of `RAND_pseudo_bytes`. According to https://jbp.io/2014/01/16/openssl-rand-api/#deprecate-randpseudobytes, `RAND_pseudo_bytes` will return -1 when it cannot generate data that is cryptographically strong. This means that the buffer will be invalid. The general implementation of `RAND_pseudo_bytes` returns 0 when it generates data that is not cryptographically strong, which seems to be the assumption in the erlang bindings. In this case, the data in the buffer was best effort, but still filled in with some PRNG data.
