### PR TITLE
Changes to make this play nicely with chef_authn

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -3,7 +3,7 @@
 CURDIR := $(shell pwd)
 BASEDIR := $(abspath $(CURDIR)/..)
 
-PROJECT := crypto2
+PROJECT := crypto
 
 ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
 ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")

--- a/c_src/crypto.c
+++ b/c_src/crypto.c
@@ -21,6 +21,7 @@ static void print_ssl_error(const char* msg) {
 static ERL_NIF_TERM atom_error;
 static ERL_NIF_TERM atom_true;
 static ERL_NIF_TERM atom_false;
+static ERL_NIF_TERM atom_sha;
 static ERL_NIF_TERM atom_sha256;
 static ERL_NIF_TERM atom_sha512;
 static ERL_NIF_TERM atom_rsa_no_padding;
@@ -301,7 +302,12 @@ static ERL_NIF_TERM rsa_verify(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv
 
 static int get_atom_nid(ERL_NIF_TERM term)
 {
-    if (term == atom_sha256) {
+    if (term == atom_sha) {
+        // This is not an allowed configuration in the fips
+        // spec. We probably want to not allow this once
+        // we have our v3 signing algorithm
+        return NID_sha1;
+    } if (term == atom_sha256) {
         return NID_sha256;
     } else if(term == atom_sha512) {
         return NID_sha512;
@@ -480,6 +486,7 @@ static int init(ErlNifEnv* env, ERL_NIF_TERM load_info)
     atom_error  = enif_make_atom(env, "error");
     atom_true   = enif_make_atom(env, "true");
     atom_false  = enif_make_atom(env, "false");
+    atom_sha = enif_make_atom(env, "sha");
     atom_sha256 = enif_make_atom(env, "sha256");
     atom_sha512 = enif_make_atom(env, "sha512");
     atom_rsa_pkcs1_padding = enif_make_atom(env,"rsa_pkcs1_padding");

--- a/c_src/crypto.c
+++ b/c_src/crypto.c
@@ -490,7 +490,7 @@ static int init(ErlNifEnv* env, ERL_NIF_TERM load_info)
      * Initialize resource types
      */
     erlrt_evp_md_ctx = enif_open_resource_type(
-        env, "crypto2",
+        env, "crypto",
         "erlrt_evp_md_ctx",
         (ErlNifResourceDtor*)evp_md_destructor,
         ERL_NIF_RT_CREATE,
@@ -531,4 +531,4 @@ static int load(ErlNifEnv* env, void** priv_data, ERL_NIF_TERM load_info)
     return 0;
 }
 
-ERL_NIF_INIT(crypto2, nif_funcs, load, NULL, NULL, NULL)
+ERL_NIF_INIT(crypto, nif_funcs, load, NULL, NULL, NULL)

--- a/src/crypto.app.src
+++ b/src/crypto.app.src
@@ -1,4 +1,4 @@
-{application, 'crypto2',
+{application, 'crypto',
  [{description, "An OTP library"},
   {vsn, "0.1.0"},
   {registered, []},

--- a/src/crypto.erl
+++ b/src/crypto.erl
@@ -1,7 +1,7 @@
 %%% Add erlang apache license here as a lot of this code
 %%% is copy pasta
 
--module('crypto2').
+-module('crypto').
 -on_load(on_load/0).
 
 %% API exports
@@ -107,9 +107,9 @@ verify(rsa, DigestType, Msg, Signature, Key) ->
 %%====================================================================
 
 on_load() ->
-  case code:priv_dir(crypto2) of
+  case code:priv_dir(crypto) of
     Path when is_list(Path) ->
-      erlang:load_nif(filename:join(Path, "crypto2"), []);
+      erlang:load_nif(filename:join(Path, "crypto"), []);
     _ ->
       {error, "Could not find library"}
   end.

--- a/test/crypto_SUITE.erl
+++ b/test/crypto_SUITE.erl
@@ -18,7 +18,7 @@
 %% %CopyrightEnd%
 %%
 
--module(crypto2_SUITE).
+-module(crypto_SUITE).
 -include_lib("common_test/include/ct.hrl").
 -compile(export_all).
 
@@ -133,26 +133,26 @@ mkint(C) when $a =< C, C =< $f ->
 hash(_, [], []) ->
     ok;
 hash(Type, [Msg | RestMsg], [Digest| RestDigest]) ->
-    case crypto2:hash(Type, Msg) of
+    case crypto:hash(Type, Msg) of
 	Digest ->
 	    hash(Type, RestMsg, RestDigest);
 	Other ->
-	    ct:fail({{crypto2, hash, [Type, Msg]}, {expected, Digest}, {got, Other}})
+	    ct:fail({{crypto, hash, [Type, Msg]}, {expected, Digest}, {got, Other}})
     end.
 
 hash_increment(Type, Increments, Digest) ->
-    State = crypto2:hash_init(Type),
+    State = crypto:hash_init(Type),
     case hash_increment(State, Increments) of
 	Digest ->
 	    ok;
 	Other ->
-	    ct:fail({{crypto2, "hash_init/update/final", [Type, Increments]}, {expected, Digest}, {got, Other}})  
+	    ct:fail({{crypto, "hash_init/update/final", [Type, Increments]}, {expected, Digest}, {got, Other}})  
     end.
 
 hash_increment(State, []) ->
-    crypto2:hash_final(State);
+    crypto:hash_final(State);
 hash_increment(State0, [Increment | Rest]) ->
-    State = crypto2:hash_update(State0, Increment),
+    State = crypto:hash_update(State0, Increment),
     hash_increment(State, Rest).
 
 iolistify(<<"Test With Truncation">>)->
@@ -223,8 +223,8 @@ long_sha512_digest() ->
 	       "de0ff244877ea60a" "4cb0432ce577c31b" "eb009c5c2c49aa2e" "4eadb217ad8cc09b").
 
 rand_bytes(_Config) ->
-    10 = byte_size(crypto2:rand_bytes(10)),
-    20 = byte_size(crypto2:strong_rand_bytes(20)).
+    10 = byte_size(crypto:rand_bytes(10)),
+    20 = byte_size(crypto:strong_rand_bytes(20)).
 
 rsa_plain() ->
     <<"7896345786348756234 Hejsan Svejsan, erlang crypto debugger"
@@ -245,8 +245,8 @@ sign_verify_tests(Type, Hashs, Msg, Public, Private) ->
                 end, [], Hashs).
 
 do_sign_verify({Type, Hash, Public, Private, Msg}) ->
-    Signature = crypto2:sign(Type, Hash, Msg, Private),
-    case crypto2:verify(Type, Hash, Msg, Signature, Public) of
+    Signature = crypto:sign(Type, Hash, Msg, Private),
+    case crypto:verify(Type, Hash, Msg, Signature, Public) of
         true ->
             negative_verify(Type, Hash, Msg, <<10,20>>, Public);
         false ->
@@ -254,7 +254,7 @@ do_sign_verify({Type, Hash, Public, Private, Msg}) ->
     end.
 
 negative_verify(Type, Hash, Msg, Signature, Public) ->
-    case crypto2:verify(Type, Hash, Msg, Signature, Public) of
+    case crypto:verify(Type, Hash, Msg, Signature, Public) of
         true ->
             ct:fail({{crypto, verify, [Type, Hash, Msg, Signature, Public]}, should_fail});
         false ->
@@ -262,8 +262,8 @@ negative_verify(Type, Hash, Msg, Signature, Public) ->
     end.
 
 do_public_encrypt({Type, Public, Private, Msg, Padding}) ->
-    PublicEcn = (catch crypto2:public_encrypt(Type, Msg, Public, Padding)),
-    case crypto2:private_decrypt(Type, PublicEcn, Private, Padding) of
+    PublicEcn = (catch crypto:public_encrypt(Type, Msg, Public, Padding)),
+    case crypto:private_decrypt(Type, PublicEcn, Private, Padding) of
         Msg ->
             ok;
         Other ->
@@ -271,8 +271,8 @@ do_public_encrypt({Type, Public, Private, Msg, Padding}) ->
     end.
 
 do_private_encrypt({Type, Public, Private, Msg, Padding}) ->
-    PrivEcn = (catch crypto2:private_encrypt(Type, Msg, Private, Padding)),
-    case crypto2:public_decrypt(rsa, PrivEcn, Public, Padding) of
+    PrivEcn = (catch crypto:private_encrypt(Type, Msg, Private, Padding)),
+    case crypto:public_decrypt(rsa, PrivEcn, Public, Padding) of
         Msg ->
             ok;
         Other ->


### PR DESCRIPTION
Renamed all the `crypto2` stuff to plain ol `crypto`

I've also added sha1 for rsa sign and verify. We can remove this when we have a replacement signing algorithm

Tested with fips mode enabled and disabled
